### PR TITLE
Change to fail gracefully when the Reddit request fails.

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 	<link rel="stylesheet" type="text/css" href="styles.css">
 </head>
 
-<body onload="createTable(hiatusList)">
+<body onload="createTable(hiatusList); requestSubredditData();">
     <div class="count">
         <h1>It has been</h1>
 		<h1 style="font-size:600%">


### PR DESCRIPTION
The easiest way to do this was to move to an asynchronous request, so if it fails it just doesn't call the callback, rather than blowing up. Synchronous requests are deprecated anyway, and may stop working in some browsers soon, so it's a good change to make regardless.

It also removes the need to have two timers, instead we only check the response when we get a valid one.